### PR TITLE
Register plugins explicitly

### DIFF
--- a/netbox/plugin.go
+++ b/netbox/plugin.go
@@ -4,6 +4,17 @@
 
 // Package netbox implements a plugin that retrieves IP lease information
 // from a NetBox server and uses it in the DHCP reply.
+//
+// Example config:
+//
+// server6:
+//   listen: '[::]547'
+//   - example:
+//   - server_id: LL aa:bb:cc:dd:ee:ff
+//   - netbox: https://netbox.coredhcp.io my_api_token
+//
+// This will send requests to https://netbox.coredhcp.io/api/<path> using
+// my_api_token for authentication.
 package netbox
 
 import (
@@ -20,18 +31,11 @@ import (
 
 var log = logger.GetLogger("plugins/netbox")
 
-// Example config:
-//
-// server6:
-//   listen: '[::]547'
-//   - example:
-//   - server_id: LL aa:bb:cc:dd:ee:ff
-//   - netbox: https://netbox.coredhcp.io my_api_token
-//
-// This will send requests to https://netbox.coredhcp.io/api/<path> using
-// my_api_token for authentication.
-func init() {
-	plugins.RegisterPlugin("netbox", setupNetbox6, setupNetbox4)
+// Plugin wraps plugin registration information
+var Plugin = plugins.Plugin{
+	Name:   "netbox",
+	Setup6: setup6,
+	Setup4: setup4,
 }
 
 var netBox *NetBox
@@ -56,7 +60,7 @@ func initNetBox(args ...string) error {
 	return nil
 }
 
-func setupNetbox6(args ...string) (handler.Handler6, error) {
+func setup6(args ...string) (handler.Handler6, error) {
 	if err := initNetBox(args...); err != nil {
 		return nil, err
 	}
@@ -64,7 +68,7 @@ func setupNetbox6(args ...string) (handler.Handler6, error) {
 	return netboxHandler6, nil
 }
 
-func setupNetbox4(args ...string) (handler.Handler4, error) {
+func setup4(args ...string) (handler.Handler4, error) {
 	if err := initNetBox(args...); err != nil {
 		return nil, err
 	}

--- a/redis/plugin.go
+++ b/redis/plugin.go
@@ -19,15 +19,18 @@ import (
 	"github.com/insomniacslk/dhcp/dhcpv6"
 )
 
+// Plugin wraps plugin registration information
+var Plugin = plugins.Plugin{
+	Name:   "redis",
+	Setup6: setup6,
+	Setup4: setup4,
+}
+
 // various global variables
 var (
 	log  = logger.GetLogger("plugins/redis")
 	pool *redis.Pool
 )
-
-func init() {
-	plugins.RegisterPlugin("redis", setupRedis6, setupRedis4)
-}
 
 // Handler6 handles DHCPv6 packets for the redis plugin
 func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
@@ -117,13 +120,13 @@ func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
 	return resp, false
 }
 
-func setupRedis6(args ...string) (handler.Handler6, error) {
+func setup6(args ...string) (handler.Handler6, error) {
 	// TODO setup function for IPv6
 	log.Warning("not implemented for IPv6")
 	return Handler6, nil
 }
 
-func setupRedis4(args ...string) (handler.Handler4, error) {
+func setup4(args ...string) (handler.Handler4, error) {
 	_, h4, err := setupRedis(false, args...)
 	return h4, err
 }


### PR DESCRIPTION
After https://github.com/coredhcp/coredhcp/pull/87 plugins must be
registered explicitly.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>